### PR TITLE
API9 - Update repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -8,7 +8,7 @@
         "AssemblyVersion": "0.2.3.0",
         "RepoUrl": "https://github.com/chalkos/Marketbuddy",
         "ApplicableVersion": "any",
-        "DalamudApiLevel": 8,
+        "DalamudApiLevel": 9,
         "DownloadLinkInstall": "https://github.com/chalkos/Marketbuddy/raw/main/latest.zip",
         "IsHide": false,
         "IsTestingExclusive": false,


### PR DESCRIPTION
Update API Level to 9

Installer is rejecting v0.2.3.0 due to the repo.json API level still being 8.