### PR TITLE
Final Value Multiples

### DIFF
--- a/Marketbuddy/Configuration.cs
+++ b/Marketbuddy/Configuration.cs
@@ -28,6 +28,18 @@ namespace Marketbuddy
         public bool UndercutUsePercent = false;
         public int UndercutPercent = 1;
 
+        /// <summary>
+        /// If enabled, the final undercut price is rounded down to the nearest multiple of <see cref="PriceRoundingMultiple"/>
+        /// (while still remaining strictly below the selected price).
+        /// </summary>
+        public bool EnablePriceRounding = false;
+
+        /// <summary>
+        /// The multiple used when <see cref="EnablePriceRounding"/> is enabled.
+        /// Example: multiple=5 will yield prices ending in 0 or 5.
+        /// </summary>
+        public int PriceRoundingMultiple = 5;
+
         public int Version { get; set; } = 0;
 
         // the below exist just to make saving/loading less cumbersome
@@ -58,6 +70,9 @@ namespace Marketbuddy
                 //    conf.HoldShiftToStop = false;
                 if (conf.UndercutPrice < 0)
                     conf.UndercutPrice = 0;
+
+                if (conf.PriceRoundingMultiple < 1)
+                    conf.PriceRoundingMultiple = 1;
             }
 
             _cachedConfig = conf;

--- a/Marketbuddy/MarketGuiEventHandler.cs
+++ b/Marketbuddy/MarketGuiEventHandler.cs
@@ -126,7 +126,21 @@ namespace Marketbuddy
                             //AtkUldManager uldManager = (*eventInfoStruct)->UldManager;
 #pragma warning disable IDE0004
                             //casts are necessary
-                            var price = conf.UndercutUsePercent ? (int)((float)getPricePerItem(nodeParam) * (1f - (float)conf.UndercutPercent / 100f)) : getPricePerItem(nodeParam) - conf.UndercutPrice;
+                            var selectedPrice = getPricePerItem(nodeParam);
+                            var price = conf.UndercutUsePercent
+                                ? (int)((float)selectedPrice * (1f - (float)conf.UndercutPercent / 100f))
+                                : selectedPrice - conf.UndercutPrice;
+
+                            // Optional: make the last digits consistent by rounding down to the nearest multiple.
+                            // Ensures we stay strictly below the selected price ("next lowest multiple").
+                            if (conf.EnablePriceRounding)
+                            {
+                                var multiple = Math.Max(1, conf.PriceRoundingMultiple);
+                                var rounded = price - (price % multiple);
+                                if (rounded >= selectedPrice)
+                                    rounded -= multiple;
+                                price = rounded;
+                            }
 #pragma warning restore IDE0004
                             price =
                                 price < Configuration.MIN_PRICE ? Configuration.MIN_PRICE

--- a/Marketbuddy/PluginUI.cs
+++ b/Marketbuddy/PluginUI.cs
@@ -159,15 +159,29 @@ namespace Marketbuddy
             ImGui.SameLine();
             ImGui.TextUnformatted("undercut over the selected price");
 
+            ImGui.Spacing();
+            DrawNestIndicator(1);
+            if (ImGui.Checkbox("Round the final undercut price down to a multiple", ref conf.EnablePriceRounding))
+                conf.Save();
+
+            DrawNestIndicator(2);
+            if (!conf.EnablePriceRounding) PushStyleDisabled();
+            ImGui.SetNextItemWidth(45);
+            if (ImGui.InputInt("##priceroundmultiple", ref conf.PriceRoundingMultiple, 0))
+                PriceRoundingChanged();
+            ImGui.SameLine();
+            ImGui.TextUnformatted("multiple (e.g., 5 => ...0 / ...5)");
+            if (!conf.EnablePriceRounding) PopStyleDisabled();
+
             DrawNestIndicator(1);
             if (ImGui.Checkbox(
-                    $"Clicking a price copies that price with a {GetUndercutText()} undercut to the clipboard",
+                    $"Clicking a price copies that price with a {GetUndercutText()} undercut (plus any rounding) to the clipboard",
                     ref conf.SaveToClipboard))
                 conf.Save();
 
             DrawNestIndicator(1);
             if (ImGui.Checkbox(
-                    $"Clicking a price sets your price as that price with a {GetUndercutText()} undercut",
+                    $"Clicking a price sets your price as that price with a {GetUndercutText()} undercut (plus any rounding)",
                     ref conf.AutoInputNewPrice))
             {
                 if (!conf.AutoInputNewPrice)
@@ -231,7 +245,7 @@ namespace Marketbuddy
             }
             else
             {
-                return $"{conf.UndercutPrice}gil";
+                return $"{conf.UndercutPrice} gil";
             }
         }
 
@@ -249,6 +263,13 @@ namespace Marketbuddy
                 conf.UndercutPrice = 0;
             if (conf.UndercutPercent > 99) conf.UndercutPercent = 99;
             if (conf.UndercutPercent < 0) conf.UndercutPercent = 0;
+            conf.Save();
+        }
+
+        private void PriceRoundingChanged()
+        {
+            if (conf.PriceRoundingMultiple < 1)
+                conf.PriceRoundingMultiple = 1;
             conf.Save();
         }
 


### PR DESCRIPTION
Allows the user to pre-set what "multiple" they want the final price to be. E.g. multiples of 5.

In response to my issue https://github.com/chalkos/Marketbuddy/issues/52